### PR TITLE
Flow type errors

### DIFF
--- a/src/__tests__/starWarsSchema.js
+++ b/src/__tests__/starWarsSchema.js
@@ -11,7 +11,6 @@ import {
   GraphQLEnumType,
   GraphQLInterfaceType,
   GraphQLObjectType,
-  GraphQLNonNull,
   GraphQLSchema,
   GraphQLString,
 } from '../type';
@@ -109,7 +108,7 @@ const characterInterface = new GraphQLInterfaceType({
   description: 'A character in the Star Wars Trilogy',
   fields: () => ({
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLString.wrapNonNull(),
       description: 'The id of the character.',
     },
     name: {
@@ -157,7 +156,7 @@ const humanType = new GraphQLObjectType({
   description: 'A humanoid creature in the Star Wars universe.',
   fields: () => ({
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLString.wrapNonNull(),
       description: 'The id of the human.',
     },
     name: {
@@ -207,7 +206,7 @@ const droidType = new GraphQLObjectType({
   description: 'A mechanical creature in the Star Wars universe.',
   fields: () => ({
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLString.wrapNonNull(),
       description: 'The id of the droid.',
     },
     name: {
@@ -272,7 +271,7 @@ const queryType = new GraphQLObjectType({
       args: {
         id: {
           description: 'id of the human',
-          type: new GraphQLNonNull(GraphQLString)
+          type: GraphQLString.wrapNonNull()
         }
       },
       resolve: (root, { id }) => getHuman(id),
@@ -282,7 +281,7 @@ const queryType = new GraphQLObjectType({
       args: {
         id: {
           description: 'id of the droid',
-          type: new GraphQLNonNull(GraphQLString)
+          type: GraphQLString.wrapNonNull()
         }
       },
       resolve: (root, { id }) => getDroid(id),

--- a/src/execution/__tests__/executor-test.js
+++ b/src/execution/__tests__/executor-test.js
@@ -16,7 +16,6 @@ import {
   GraphQLBoolean,
   GraphQLInt,
   GraphQLString,
-  GraphQLNonNull,
 } from '../../type';
 
 describe('Execute: Handles basic execution tasks', () => {
@@ -500,11 +499,11 @@ describe('Execute: Handles basic execution tasks', () => {
           resolve: () => ({}),
         },
         nonNullA: {
-          type: new GraphQLNonNull(A),
+          type: A.wrapNonNull(),
           resolve: () => ({}),
         },
         throws: {
-          type: new GraphQLNonNull(GraphQLString),
+          type: GraphQLString.wrapNonNull(),
           resolve: () => {
             throw new Error('Catch me if you can');
           },

--- a/src/execution/__tests__/lists-test.js
+++ b/src/execution/__tests__/lists-test.js
@@ -276,7 +276,7 @@ describe('Execute: Handles list nullability', () => {
   });
 
   describe('[T!]', () => {
-    const type = (new GraphQLNonNull(GraphQLInt)).wrapList();
+    const type = (GraphQLInt.wrapNonNull()).wrapList();
 
     describe('Array<T>', () => {
 
@@ -369,7 +369,7 @@ describe('Execute: Handles list nullability', () => {
 
   describe('[T!]!', () => {
     const type =
-      new GraphQLNonNull((new GraphQLNonNull(GraphQLInt)).wrapList());
+      new GraphQLNonNull((GraphQLInt.wrapNonNull()).wrapList());
 
     describe('Array<T>', () => {
 

--- a/src/execution/__tests__/nonnull-test.js
+++ b/src/execution/__tests__/nonnull-test.js
@@ -16,7 +16,6 @@ import {
   GraphQLSchema,
   GraphQLObjectType,
   GraphQLString,
-  GraphQLNonNull
 } from '../../type';
 
 const syncError = new Error('sync');
@@ -106,13 +105,13 @@ const dataType = new GraphQLObjectType({
   name: 'DataType',
   fields: () => ({
     sync: { type: GraphQLString },
-    nonNullSync: { type: new GraphQLNonNull(GraphQLString) },
+    nonNullSync: { type: GraphQLString.wrapNonNull() },
     promise: { type: GraphQLString },
-    nonNullPromise: { type: new GraphQLNonNull(GraphQLString) },
+    nonNullPromise: { type: GraphQLString.wrapNonNull() },
     nest: { type: dataType },
-    nonNullNest: { type: new GraphQLNonNull(dataType) },
+    nonNullNest: { type: dataType.wrapNonNull() },
     promiseNest: { type: dataType },
-    nonNullPromiseNest: { type: new GraphQLNonNull(dataType) },
+    nonNullPromiseNest: { type: dataType.wrapNonNull() },
   })
 });
 const schema = new GraphQLSchema({

--- a/src/execution/__tests__/schema-test.js
+++ b/src/execution/__tests__/schema-test.js
@@ -13,7 +13,6 @@ import { parse } from '../../language';
 import {
   GraphQLSchema,
   GraphQLObjectType,
-  GraphQLNonNull,
   GraphQLInt,
   GraphQLString,
   GraphQLBoolean,
@@ -50,7 +49,7 @@ describe('Execute: Handles execution with a complex schema', () => {
     const BlogArticle = new GraphQLObjectType({
       name: 'Article',
       fields: {
-        id: { type: new GraphQLNonNull(GraphQLString) },
+        id: { type: GraphQLString.wrapNonNull() },
         isPublished: { type: GraphQLBoolean },
         author: { type: BlogAuthor },
         title: { type: GraphQLString },

--- a/src/execution/__tests__/variables-test.js
+++ b/src/execution/__tests__/variables-test.js
@@ -49,7 +49,7 @@ const TestInputObject = new GraphQLInputObjectType({
   fields: {
     a: { type: GraphQLString },
     b: { type: GraphQLString.wrapList() },
-    c: { type: new GraphQLNonNull(GraphQLString) },
+    c: { type: GraphQLString.wrapNonNull() },
     d: { type: TestComplexScalar },
   }
 });
@@ -57,8 +57,8 @@ const TestInputObject = new GraphQLInputObjectType({
 const TestNestedInputObject = new GraphQLInputObjectType({
   name: 'TestNestedInputObject',
   fields: {
-    na: { type: new GraphQLNonNull(TestInputObject) },
-    nb: { type: new GraphQLNonNull(GraphQLString) },
+    na: { type: TestInputObject.wrapNonNull() },
+    nb: { type: GraphQLString.wrapNonNull() },
   },
 });
 
@@ -77,7 +77,7 @@ const TestType = new GraphQLObjectType({
     },
     fieldWithNonNullableStringInput: {
       type: GraphQLString,
-      args: { input: { type: new GraphQLNonNull(GraphQLString) } },
+      args: { input: { type: GraphQLString.wrapNonNull() } },
       resolve: (_, { input }) => input && JSON.stringify(input)
     },
     fieldWithDefaultArgumentValue: {
@@ -106,13 +106,13 @@ const TestType = new GraphQLObjectType({
     },
     listNN: {
       type: GraphQLString,
-      args: { input: { type: (new GraphQLNonNull(GraphQLString)).wrapList() } },
+      args: { input: { type: (GraphQLString.wrapNonNull()).wrapList() } },
       resolve: (_, { input }) => input && JSON.stringify(input)
     },
     nnListNN: {
       type: GraphQLString,
       args: { input: { type:
-        new GraphQLNonNull((new GraphQLNonNull(GraphQLString)).wrapList())
+        new GraphQLNonNull((GraphQLString.wrapNonNull()).wrapList())
       } },
       resolve: (_, { input }) => input && JSON.stringify(input)
     },

--- a/src/type/__tests__/validation-test.js
+++ b/src/type/__tests__/validation-test.js
@@ -71,7 +71,7 @@ const SomeInputObjectType = new GraphQLInputObjectType({
 function withModifiers(types) {
   return types
     .concat(types.map(type => type.wrapList()))
-    .concat(types.map(type => new GraphQLNonNull(type)))
+    .concat(types.map(type => type.wrapNonNull()))
     .concat(types.map(type => new GraphQLNonNull(type.wrapList())));
 }
 
@@ -1630,11 +1630,11 @@ describe('Type System: NonNull must accept GraphQL types', () => {
     SomeEnumType,
     SomeInputObjectType,
     GraphQLString.wrapList(),
-    (new GraphQLNonNull(GraphQLString)).wrapList(),
+    (GraphQLString.wrapNonNull()).wrapList(),
   ];
 
   const notNullableTypes = [
-    new GraphQLNonNull(GraphQLString),
+    GraphQLString.wrapNonNull(),
     {},
     String,
     undefined,
@@ -1643,13 +1643,13 @@ describe('Type System: NonNull must accept GraphQL types', () => {
 
   nullableTypes.forEach(type => {
     it(`accepts an type as nullable type of non-null: ${type}`, () => {
-      expect(() => new GraphQLNonNull(type)).not.to.throw();
+      expect(() => type.wrapNonNull()).not.to.throw();
     });
   });
 
   notNullableTypes.forEach(type => {
     it(`rejects a non-type as nullable type of non-null: ${type}`, () => {
-      expect(() => new GraphQLNonNull(type)).to.throw(
+      expect(() => type.wrapNonNull()).to.throw(
         `Can only create NonNull of a Nullable GraphQLType but got: ${type}.`
       );
     });
@@ -1781,7 +1781,7 @@ describe('Objects must adhere to Interface they implement', () => {
             type: GraphQLString,
             args: {
               input: { type: GraphQLString },
-              anotherInput: { type: new GraphQLNonNull(GraphQLString) },
+              anotherInput: { type: GraphQLString.wrapNonNull() },
             }
           }
         }
@@ -2085,7 +2085,7 @@ describe('Objects must adhere to Interface they implement', () => {
         name: 'AnotherObject',
         interfaces: [ AnotherInterface ],
         fields: {
-          field: { type: new GraphQLNonNull(GraphQLString) }
+          field: { type: GraphQLString.wrapNonNull() }
         }
       });
 
@@ -2099,7 +2099,7 @@ describe('Objects must adhere to Interface they implement', () => {
         name: 'AnotherInterface',
         resolveType: () => null,
         fields: {
-          field: { type: new GraphQLNonNull(GraphQLString) }
+          field: { type: GraphQLString.wrapNonNull() }
         }
       });
 

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -310,6 +310,7 @@ export class GraphQLScalarType {
 
   _scalarConfig: GraphQLScalarTypeConfig<*, *>;
   _wrappedList: ?GraphQLList<*>;
+  _wrappedNonNull: ?GraphQLNonNull<*>;
 
   constructor(config: GraphQLScalarTypeConfig<*, *>): void {
     assertValidName(config.name);
@@ -369,6 +370,12 @@ export class GraphQLScalarType {
 
   wrapList(): GraphQLList<*> {
     return this._wrappedList || (this._wrappedList = new GraphQLList(this));
+  }
+
+  wrapNonNull(): GraphQLNonNull<*> {
+    return this._wrappedNonNull || (this._wrappedNonNull =
+      new GraphQLNonNull(this)
+    );
   }
 
   toJSON: () => string;
@@ -439,6 +446,7 @@ export class GraphQLObjectType {
   _fields: GraphQLFieldMap<*, *>;
   _interfaces: Array<GraphQLInterfaceType>;
   _wrappedList: ?GraphQLList<*>;
+  _wrappedNonNull: ?GraphQLNonNull<*>;
 
   constructor(config: GraphQLObjectTypeConfig<*, *>): void {
     assertValidName(config.name, config.isIntrospection);
@@ -474,6 +482,12 @@ export class GraphQLObjectType {
 
   wrapList(): GraphQLList<*> {
     return this._wrappedList || (this._wrappedList = new GraphQLList(this));
+  }
+
+  wrapNonNull(): GraphQLNonNull<*> {
+    return this._wrappedNonNull || (this._wrappedNonNull =
+      new GraphQLNonNull(this)
+    );
   }
 
   toJSON: () => string;
@@ -729,6 +743,7 @@ export class GraphQLInterfaceType {
   _typeConfig: GraphQLInterfaceTypeConfig<*, *>;
   _fields: GraphQLFieldMap<*, *>;
   _wrappedList: ?GraphQLList<*>;
+  _wrappedNonNull: ?GraphQLNonNull<*>;
 
   constructor(config: GraphQLInterfaceTypeConfig<*, *>): void {
     assertValidName(config.name);
@@ -756,6 +771,12 @@ export class GraphQLInterfaceType {
 
   wrapList(): GraphQLList<*> {
     return this._wrappedList || (this._wrappedList = new GraphQLList(this));
+  }
+
+  wrapNonNull(): GraphQLNonNull<*> {
+    return this._wrappedNonNull || (this._wrappedNonNull =
+      new GraphQLNonNull(this)
+    );
   }
 
   toJSON: () => string;
@@ -814,6 +835,7 @@ export class GraphQLUnionType {
   _typeConfig: GraphQLUnionTypeConfig<*, *>;
   _types: Array<GraphQLObjectType>;
   _wrappedList: ?GraphQLList<*>;
+  _wrappedNonNull: ?GraphQLNonNull<*>;
 
   constructor(config: GraphQLUnionTypeConfig<*, *>): void {
     assertValidName(config.name);
@@ -842,6 +864,12 @@ export class GraphQLUnionType {
 
   wrapList(): GraphQLList<*> {
     return this._wrappedList || (this._wrappedList = new GraphQLList(this));
+  }
+
+  wrapNonNull(): GraphQLNonNull<*> {
+    return this._wrappedNonNull || (this._wrappedNonNull =
+      new GraphQLNonNull(this)
+    );
   }
 
   toJSON: () => string;
@@ -936,6 +964,7 @@ export class GraphQLEnumType/* <T> */ {
   _valueLookup: Map<any/* T */, GraphQLEnumValue>;
   _nameLookup: ObjMap<GraphQLEnumValue>;
   _wrappedList: ?GraphQLList<*>;
+  _wrappedNonNull: ?GraphQLNonNull<*>;
 
   constructor(config: GraphQLEnumTypeConfig/* <T> */): void {
     this.name = config.name;
@@ -1015,6 +1044,12 @@ export class GraphQLEnumType/* <T> */ {
 
   wrapList(): GraphQLList<*> {
     return this._wrappedList || (this._wrappedList = new GraphQLList(this));
+  }
+
+  wrapNonNull(): GraphQLNonNull<*> {
+    return this._wrappedNonNull || (this._wrappedNonNull =
+      new GraphQLNonNull(this)
+    );
   }
 
   toJSON: () => string;
@@ -1125,6 +1160,7 @@ export class GraphQLInputObjectType {
   _typeConfig: GraphQLInputObjectTypeConfig;
   _fields: GraphQLInputFieldMap;
   _wrappedList: ?GraphQLList<*>;
+  _wrappedNonNull: ?GraphQLNonNull<*>;
 
   constructor(config: GraphQLInputObjectTypeConfig): void {
     assertValidName(config.name);
@@ -1179,6 +1215,12 @@ export class GraphQLInputObjectType {
 
   wrapList(): GraphQLList<*> {
     return this._wrappedList || (this._wrappedList = new GraphQLList(this));
+  }
+
+  wrapNonNull(): GraphQLNonNull<*> {
+    return this._wrappedNonNull || (this._wrappedNonNull =
+      new GraphQLNonNull(this)
+    );
   }
 
   toJSON: () => string;
@@ -1241,6 +1283,7 @@ export type GraphQLInputFieldMap =
 export class GraphQLList<T: GraphQLType> {
   ofType: T;
   _wrappedList: ?GraphQLList<*>;
+  _wrappedNonNull: ?GraphQLNonNull<*>;
 
   constructor(type: T): void {
     invariant(
@@ -1256,6 +1299,12 @@ export class GraphQLList<T: GraphQLType> {
 
   wrapList(): GraphQLList<*> {
     return this._wrappedList || (this._wrappedList = new GraphQLList(this));
+  }
+
+  wrapNonNull(): GraphQLNonNull<*> {
+    return this._wrappedNonNull || (this._wrappedNonNull =
+      new GraphQLNonNull(this)
+    );
   }
 
   toJSON: () => string;

--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import { isInputType, GraphQLNonNull } from './definition';
+import { isInputType } from './definition';
 import type {
   GraphQLFieldConfigArgumentMap,
   GraphQLArgument
@@ -118,7 +118,7 @@ export const GraphQLIncludeDirective = new GraphQLDirective({
   ],
   args: {
     if: {
-      type: new GraphQLNonNull(GraphQLBoolean),
+      type: GraphQLBoolean.wrapNonNull(),
       description: 'Included when true.'
     }
   },
@@ -139,7 +139,7 @@ export const GraphQLSkipDirective = new GraphQLDirective({
   ],
   args: {
     if: {
-      type: new GraphQLNonNull(GraphQLBoolean),
+      type: GraphQLBoolean.wrapNonNull(),
       description: 'Skipped when true.'
     }
   },

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -36,7 +36,7 @@ export const __Schema = new GraphQLObjectType({
   fields: () => ({
     types: {
       description: 'A list of all types supported by this server.',
-      type: new GraphQLNonNull((new GraphQLNonNull(__Type)).wrapList()),
+      type: new GraphQLNonNull((__Type.wrapNonNull()).wrapList()),
       resolve(schema) {
         const typeMap = schema.getTypeMap();
         return Object.keys(typeMap).map(key => typeMap[key]);
@@ -44,7 +44,7 @@ export const __Schema = new GraphQLObjectType({
     },
     queryType: {
       description: 'The type that query operations will be rooted at.',
-      type: new GraphQLNonNull(__Type),
+      type: __Type.wrapNonNull(),
       resolve: schema => schema.getQueryType()
     },
     mutationType: {
@@ -62,7 +62,7 @@ export const __Schema = new GraphQLObjectType({
     directives: {
       description: 'A list of all directives supported by this server.',
       type:
-        new GraphQLNonNull((new GraphQLNonNull(__Directive)).wrapList()),
+        new GraphQLNonNull((__Directive.wrapNonNull()).wrapList()),
       resolve: schema => schema.getDirectives(),
     }
   })
@@ -79,7 +79,7 @@ export const __Directive = new GraphQLObjectType({
     'conditionally including or skipping a field. Directives provide this by ' +
     'describing additional information to the executor.',
   fields: () => ({
-    name: { type: new GraphQLNonNull(GraphQLString) },
+    name: { type: GraphQLString.wrapNonNull() },
     description: { type: GraphQLString },
     locations: {
       type: new GraphQLNonNull((new GraphQLNonNull(
@@ -88,14 +88,14 @@ export const __Directive = new GraphQLObjectType({
     },
     args: {
       type:
-        new GraphQLNonNull((new GraphQLNonNull(__InputValue)).wrapList()),
+        new GraphQLNonNull((__InputValue.wrapNonNull()).wrapList()),
       resolve: directive => directive.args || []
     },
     // NOTE: the following three fields are deprecated and are no longer part
     // of the GraphQL specification.
     onOperation: {
       deprecationReason: 'Use `locations`.',
-      type: new GraphQLNonNull(GraphQLBoolean),
+      type: GraphQLBoolean.wrapNonNull(),
       resolve: d =>
         d.locations.indexOf(DirectiveLocation.QUERY) !== -1 ||
         d.locations.indexOf(DirectiveLocation.MUTATION) !== -1 ||
@@ -103,7 +103,7 @@ export const __Directive = new GraphQLObjectType({
     },
     onFragment: {
       deprecationReason: 'Use `locations`.',
-      type: new GraphQLNonNull(GraphQLBoolean),
+      type: GraphQLBoolean.wrapNonNull(),
       resolve: d =>
         d.locations.indexOf(DirectiveLocation.FRAGMENT_SPREAD) !== -1 ||
         d.locations.indexOf(DirectiveLocation.INLINE_FRAGMENT) !== -1 ||
@@ -111,7 +111,7 @@ export const __Directive = new GraphQLObjectType({
     },
     onField: {
       deprecationReason: 'Use `locations`.',
-      type: new GraphQLNonNull(GraphQLBoolean),
+      type: GraphQLBoolean.wrapNonNull(),
       resolve: d => d.locations.indexOf(DirectiveLocation.FIELD) !== -1
     },
   }),
@@ -213,7 +213,7 @@ export const __Type = new GraphQLObjectType({
     'at runtime. List and NonNull types compose other types.',
   fields: () => ({
     kind: {
-      type: new GraphQLNonNull(__TypeKind),
+      type: __TypeKind.wrapNonNull(),
       resolve(type) {
         if (type instanceof GraphQLScalarType) {
           return TypeKind.SCALAR;
@@ -238,7 +238,7 @@ export const __Type = new GraphQLObjectType({
     name: { type: GraphQLString },
     description: { type: GraphQLString },
     fields: {
-      type: (new GraphQLNonNull(__Field)).wrapList(),
+      type: (__Field.wrapNonNull()).wrapList(),
       args: {
         includeDeprecated: { type: GraphQLBoolean, defaultValue: false }
       },
@@ -257,7 +257,7 @@ export const __Type = new GraphQLObjectType({
       }
     },
     interfaces: {
-      type: (new GraphQLNonNull(__Type)).wrapList(),
+      type: (__Type.wrapNonNull()).wrapList(),
       resolve(type) {
         if (type instanceof GraphQLObjectType) {
           return type.getInterfaces();
@@ -265,7 +265,7 @@ export const __Type = new GraphQLObjectType({
       }
     },
     possibleTypes: {
-      type: (new GraphQLNonNull(__Type)).wrapList(),
+      type: (__Type.wrapNonNull()).wrapList(),
       resolve(type, args, context, { schema }) {
         if (isAbstractType(type)) {
           return schema.getPossibleTypes(type);
@@ -273,7 +273,7 @@ export const __Type = new GraphQLObjectType({
       }
     },
     enumValues: {
-      type: (new GraphQLNonNull(__EnumValue)).wrapList(),
+      type: (__EnumValue.wrapNonNull()).wrapList(),
       args: {
         includeDeprecated: { type: GraphQLBoolean, defaultValue: false }
       },
@@ -288,7 +288,7 @@ export const __Type = new GraphQLObjectType({
       }
     },
     inputFields: {
-      type: (new GraphQLNonNull(__InputValue)).wrapList(),
+      type: (__InputValue.wrapNonNull()).wrapList(),
       resolve(type) {
         if (type instanceof GraphQLInputObjectType) {
           const fieldMap = type.getFields();
@@ -307,15 +307,15 @@ export const __Field = new GraphQLObjectType({
     'Object and Interface types are described by a list of Fields, each of ' +
     'which has a name, potentially a list of arguments, and a return type.',
   fields: () => ({
-    name: { type: new GraphQLNonNull(GraphQLString) },
+    name: { type: GraphQLString.wrapNonNull() },
     description: { type: GraphQLString },
     args: {
       type:
-        new GraphQLNonNull((new GraphQLNonNull(__InputValue)).wrapList()),
+        new GraphQLNonNull((__InputValue.wrapNonNull()).wrapList()),
       resolve: field => field.args || []
     },
-    type: { type: new GraphQLNonNull(__Type) },
-    isDeprecated: { type: new GraphQLNonNull(GraphQLBoolean) },
+    type: { type: __Type.wrapNonNull() },
+    isDeprecated: { type: GraphQLBoolean.wrapNonNull() },
     deprecationReason: {
       type: GraphQLString,
     }
@@ -330,9 +330,9 @@ export const __InputValue = new GraphQLObjectType({
     'InputObject are represented as Input Values which describe their type ' +
     'and optionally a default value.',
   fields: () => ({
-    name: { type: new GraphQLNonNull(GraphQLString) },
+    name: { type: GraphQLString.wrapNonNull() },
     description: { type: GraphQLString },
-    type: { type: new GraphQLNonNull(__Type) },
+    type: { type: __Type.wrapNonNull() },
     defaultValue: {
       type: GraphQLString,
       description:
@@ -353,9 +353,9 @@ export const __EnumValue = new GraphQLObjectType({
     'a placeholder for a string or numeric value. However an Enum value is ' +
     'returned in a JSON response as a string.',
   fields: () => ({
-    name: { type: new GraphQLNonNull(GraphQLString) },
+    name: { type: GraphQLString.wrapNonNull() },
     description: { type: GraphQLString },
-    isDeprecated: { type: new GraphQLNonNull(GraphQLBoolean) },
+    isDeprecated: { type: GraphQLBoolean.wrapNonNull() },
     deprecationReason: {
       type: GraphQLString,
     }
@@ -427,7 +427,7 @@ export const __TypeKind = new GraphQLEnumType({
 
 export const SchemaMetaFieldDef: GraphQLField<*, *> = {
   name: '__schema',
-  type: new GraphQLNonNull(__Schema),
+  type: __Schema.wrapNonNull(),
   description: 'Access the current type schema of this server.',
   args: [],
   resolve: (source, args, context, { schema }) => schema
@@ -438,7 +438,7 @@ export const TypeMetaFieldDef: GraphQLField<*, *> = {
   type: __Type,
   description: 'Request the type information of a single type.',
   args: [
-    { name: 'name', type: new GraphQLNonNull(GraphQLString) }
+    { name: 'name', type: GraphQLString.wrapNonNull() }
   ],
   resolve: (source, { name }, context, { schema }) =>
     schema.getType(name)
@@ -446,7 +446,7 @@ export const TypeMetaFieldDef: GraphQLField<*, *> = {
 
 export const TypeNameMetaFieldDef: GraphQLField<*, *> = {
   name: '__typename',
-  type: new GraphQLNonNull(GraphQLString),
+  type: GraphQLString.wrapNonNull(),
   description: 'The name of the current Object type at runtime.',
   args: [],
   resolve: (source, args, context, { parentType }) => parentType.name

--- a/src/utilities/__tests__/astFromValue-test.js
+++ b/src/utilities/__tests__/astFromValue-test.js
@@ -16,7 +16,6 @@ import {
   GraphQLString,
   GraphQLBoolean,
   GraphQLID,
-  GraphQLNonNull,
 } from '../../type';
 
 
@@ -49,7 +48,7 @@ describe('astFromValue', () => {
       { kind: 'BooleanValue', value: true }
     );
 
-    const NonNullBoolean = new GraphQLNonNull(GraphQLBoolean);
+    const NonNullBoolean = GraphQLBoolean.wrapNonNull();
     expect(astFromValue(0, NonNullBoolean)).to.deep.equal(
       { kind: 'BooleanValue', value: false }
     );
@@ -157,7 +156,7 @@ describe('astFromValue', () => {
   });
 
   it('does not converts NonNull values to NullValue', () => {
-    const NonNullBoolean = new GraphQLNonNull(GraphQLBoolean);
+    const NonNullBoolean = GraphQLBoolean.wrapNonNull();
     expect(astFromValue(null, NonNullBoolean)).to.deep.equal(
       null
     );

--- a/src/utilities/__tests__/buildClientSchema-test.js
+++ b/src/utilities/__tests__/buildClientSchema-test.js
@@ -287,14 +287,14 @@ describe('Type System: build schema from introspection', () => {
           string: { type: GraphQLString },
           listOfString: { type: GraphQLString.wrapList() },
           nonNullString: {
-            type: new GraphQLNonNull(GraphQLString)
+            type: GraphQLString.wrapNonNull()
           },
           nonNullListOfString: {
             type: new GraphQLNonNull(GraphQLString.wrapList())
           },
           nonNullListOfNonNullString: {
             type: new GraphQLNonNull(
-              (new GraphQLNonNull(GraphQLString)).wrapList()
+              (GraphQLString.wrapNonNull()).wrapList()
             )
           },
         }
@@ -329,7 +329,7 @@ describe('Type System: build schema from introspection', () => {
               },
               requiredArg: {
                 description: 'This is a required arg',
-                type: new GraphQLNonNull(GraphQLBoolean)
+                type: GraphQLBoolean.wrapNonNull()
               }
             }
           }
@@ -437,11 +437,11 @@ describe('Type System: build schema from introspection', () => {
       fields: {
         street: {
           description: 'What street is this address?',
-          type: new GraphQLNonNull(GraphQLString)
+          type: GraphQLString.wrapNonNull()
         },
         city: {
           description: 'The city the address is within?',
-          type: new GraphQLNonNull(GraphQLString)
+          type: GraphQLString.wrapNonNull()
         },
         country: {
           description: 'The country (blank will assume USA).',
@@ -779,7 +779,7 @@ describe('Type System: build schema from introspection', () => {
             foo: {
               type: (new GraphQLNonNull((
                 new GraphQLNonNull((new GraphQLNonNull(
-                (new GraphQLNonNull(GraphQLString)).wrapList()
+                (GraphQLString.wrapNonNull()).wrapList()
               )).wrapList())).wrapList())).wrapList()
             }
           }
@@ -802,7 +802,7 @@ describe('Type System: build schema from introspection', () => {
               type: new GraphQLNonNull((
                 new GraphQLNonNull((
                 new GraphQLNonNull((
-                new GraphQLNonNull(GraphQLString)
+                GraphQLString.wrapNonNull()
               ).wrapList())).wrapList())).wrapList())
             }
           }

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -84,7 +84,7 @@ const testSchema = new GraphQLSchema({
       someUnion: { type: SomeUnionType },
       someEnum: { type: SomeEnumType },
       someInterface: {
-        args: { id: { type: new GraphQLNonNull(GraphQLID) } },
+        args: { id: { type: GraphQLID.wrapNonNull() } },
         type: SomeInterfaceType
       },
     })

--- a/src/utilities/__tests__/findBreakingChanges-test.js
+++ b/src/utilities/__tests__/findBreakingChanges-test.js
@@ -151,18 +151,18 @@ describe('findBreakingChanges', () => {
         field6: { type: GraphQLString },
         field7: { type: GraphQLString.wrapList() },
         field8: { type: GraphQLInt },
-        field9: { type: new GraphQLNonNull(GraphQLInt) },
+        field9: { type: GraphQLInt.wrapNonNull() },
         field10: { type: new GraphQLNonNull(GraphQLInt.wrapList()) },
         field11: { type: GraphQLInt },
         field12: { type: GraphQLInt.wrapList() },
-        field13: { type: (new GraphQLNonNull(GraphQLInt)).wrapList() },
+        field13: { type: (GraphQLInt.wrapNonNull()).wrapList() },
         field14: { type: GraphQLInt.wrapList() },
         field15: { type: GraphQLInt.wrapList().wrapList() },
-        field16: { type: new GraphQLNonNull(GraphQLInt) },
+        field16: { type: GraphQLInt.wrapNonNull() },
         field17: { type: GraphQLInt.wrapList() },
         field18: {
           type: (new GraphQLNonNull(
-            (new GraphQLNonNull(GraphQLInt)).wrapList())).wrapList(),
+            (GraphQLInt.wrapNonNull()).wrapList())).wrapList(),
         },
       }
     });
@@ -175,18 +175,18 @@ describe('findBreakingChanges', () => {
         field5: { type: GraphQLString },
         field6: { type: GraphQLString.wrapList() },
         field7: { type: GraphQLString },
-        field8: { type: new GraphQLNonNull(GraphQLInt) },
+        field8: { type: GraphQLInt.wrapNonNull() },
         field9: { type: GraphQLInt },
         field10: { type: GraphQLInt.wrapList() },
         field11: { type: new GraphQLNonNull(GraphQLInt.wrapList()) },
-        field12: { type: (new GraphQLNonNull(GraphQLInt)).wrapList() },
+        field12: { type: (GraphQLInt.wrapNonNull()).wrapList() },
         field13: { type: GraphQLInt.wrapList() },
         field14: { type: GraphQLInt.wrapList().wrapList() },
         field15: { type: GraphQLInt.wrapList() },
         field16: { type: new GraphQLNonNull(GraphQLInt.wrapList()) },
         field17: { type: new GraphQLNonNull(GraphQLInt.wrapList()) },
         field18: {
-          type: (new GraphQLNonNull(GraphQLInt)).wrapList().wrapList(),
+          type: (GraphQLInt.wrapNonNull()).wrapList().wrapList(),
         },
       }
     });
@@ -279,7 +279,7 @@ describe('findBreakingChanges', () => {
             type: GraphQLString.wrapList(),
           },
           field4: {
-            type: new GraphQLNonNull(GraphQLString),
+            type: GraphQLString.wrapNonNull(),
           },
           field5: {
             type: GraphQLString,
@@ -297,7 +297,7 @@ describe('findBreakingChanges', () => {
             type: GraphQLInt.wrapList(),
           },
           field10: {
-            type: (new GraphQLNonNull(GraphQLInt)).wrapList(),
+            type: (GraphQLInt.wrapNonNull()).wrapList(),
           },
           field11: {
             type: GraphQLInt.wrapList(),
@@ -306,7 +306,7 @@ describe('findBreakingChanges', () => {
             type: GraphQLInt.wrapList().wrapList(),
           },
           field13: {
-            type: new GraphQLNonNull(GraphQLInt),
+            type: GraphQLInt.wrapNonNull(),
           },
           field14: {
             type: (new GraphQLNonNull(
@@ -331,7 +331,7 @@ describe('findBreakingChanges', () => {
             type: GraphQLString,
           },
           field5: {
-            type: new GraphQLNonNull(GraphQLString),
+            type: GraphQLString.wrapNonNull(),
           },
           field6: {
             type: new GraphQLNonNull(GraphQLInt.wrapList()),
@@ -343,7 +343,7 @@ describe('findBreakingChanges', () => {
             type: new GraphQLNonNull(GraphQLInt.wrapList()),
           },
           field9: {
-            type: (new GraphQLNonNull(GraphQLInt)).wrapList(),
+            type: (GraphQLInt.wrapNonNull()).wrapList(),
           },
           field10: {
             type: GraphQLInt.wrapList(),
@@ -362,7 +362,7 @@ describe('findBreakingChanges', () => {
           },
           field15: {
             type: (new GraphQLNonNull(
-              (new GraphQLNonNull(GraphQLInt)).wrapList())).wrapList(),
+              (GraphQLInt.wrapNonNull()).wrapList())).wrapList(),
           },
         },
       });
@@ -457,7 +457,7 @@ describe('findBreakingChanges', () => {
           type: GraphQLString,
         },
         requiredField: {
-          type: new GraphQLNonNull(GraphQLInt),
+          type: GraphQLInt.wrapNonNull(),
         },
         optionalField: {
           type: GraphQLBoolean,
@@ -703,10 +703,10 @@ describe('findBreakingChanges', () => {
               type: GraphQLString,
             },
             arg5: {
-              type: new GraphQLNonNull(GraphQLString),
+              type: GraphQLString.wrapNonNull(),
             },
             arg6: {
-              type: new GraphQLNonNull(GraphQLString),
+              type: GraphQLString.wrapNonNull(),
             },
             arg7: {
               type: new GraphQLNonNull(GraphQLInt.wrapList()),
@@ -718,7 +718,7 @@ describe('findBreakingChanges', () => {
               type: GraphQLInt.wrapList(),
             },
             arg10: {
-              type: (new GraphQLNonNull(GraphQLInt)).wrapList(),
+              type: (GraphQLInt.wrapNonNull()).wrapList(),
             },
             arg11: {
               type: GraphQLInt.wrapList(),
@@ -727,7 +727,7 @@ describe('findBreakingChanges', () => {
               type: GraphQLInt.wrapList().wrapList(),
             },
             arg13: {
-              type: new GraphQLNonNull(GraphQLInt),
+              type: GraphQLInt.wrapNonNull(),
             },
             arg14: {
               type: (new GraphQLNonNull(
@@ -758,13 +758,13 @@ describe('findBreakingChanges', () => {
               type: GraphQLString,
             },
             arg4: {
-              type: new GraphQLNonNull(GraphQLString),
+              type: GraphQLString.wrapNonNull(),
             },
             arg5: {
               type: GraphQLInt,
             },
             arg6: {
-              type: new GraphQLNonNull(GraphQLInt),
+              type: GraphQLInt.wrapNonNull(),
             },
             arg7: {
               type: GraphQLInt.wrapList(),
@@ -773,7 +773,7 @@ describe('findBreakingChanges', () => {
               type: new GraphQLNonNull(GraphQLInt.wrapList()),
             },
             arg9: {
-              type: (new GraphQLNonNull(GraphQLInt)).wrapList(),
+              type: (GraphQLInt.wrapNonNull()).wrapList(),
             },
             arg10: {
               type: GraphQLInt.wrapList(),
@@ -792,7 +792,7 @@ describe('findBreakingChanges', () => {
             },
             arg15: {
               type: (new GraphQLNonNull(
-                (new GraphQLNonNull(GraphQLInt)).wrapList())).wrapList(),
+                (GraphQLInt.wrapNonNull()).wrapList())).wrapList(),
             },
           },
         },
@@ -904,7 +904,7 @@ describe('findBreakingChanges', () => {
               type: GraphQLString,
             },
             newRequiredArg: {
-              type: new GraphQLNonNull(GraphQLString),
+              type: GraphQLString.wrapNonNull(),
             },
             newOptionalArg: {
               type: GraphQLInt,
@@ -964,7 +964,7 @@ describe('findBreakingChanges', () => {
           type: GraphQLInt,
           args: {
             arg1: {
-              type: new GraphQLNonNull(GraphQLInt),
+              type: GraphQLInt.wrapNonNull(),
             },
             arg2: {
               type: inputType1a,
@@ -981,7 +981,7 @@ describe('findBreakingChanges', () => {
           type: GraphQLInt,
           args: {
             arg1: {
-              type: new GraphQLNonNull(GraphQLInt),
+              type: GraphQLInt.wrapNonNull(),
             },
             arg2: {
               type: inputType1b,
@@ -1018,7 +1018,7 @@ describe('findBreakingChanges', () => {
           type: GraphQLString,
           args: {
             name: {
-              type: new GraphQLNonNull(GraphQLString),
+              type: GraphQLString.wrapNonNull(),
             },
           },
         },

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -23,7 +23,6 @@ import {
   GraphQLString,
   GraphQLInt,
   GraphQLBoolean,
-  GraphQLNonNull,
 } from '../../';
 
 
@@ -44,7 +43,7 @@ function listOf(type) {
 }
 
 function nonNull(type) {
-  return new GraphQLNonNull(type);
+  return type.wrapNonNull();
 }
 
 describe('Type System Printer', () => {

--- a/src/utilities/__tests__/typeComparators-test.js
+++ b/src/utilities/__tests__/typeComparators-test.js
@@ -12,7 +12,6 @@ import {
   GraphQLString,
   GraphQLInt,
   GraphQLFloat,
-  GraphQLNonNull,
   GraphQLObjectType,
   GraphQLInterfaceType,
   GraphQLUnionType,
@@ -47,15 +46,15 @@ describe('typeComparators', () => {
     it('non-null of same type are equal', () => {
       expect(
         isEqualType(
-          new GraphQLNonNull(GraphQLInt),
-          new GraphQLNonNull(GraphQLInt)
+          GraphQLInt.wrapNonNull(),
+          GraphQLInt.wrapNonNull()
         )
       ).to.equal(true);
     });
 
     it('non-null is not equal to nullable', () => {
       expect(
-        isEqualType(new GraphQLNonNull(GraphQLInt), GraphQLInt)
+        isEqualType(GraphQLInt.wrapNonNull(), GraphQLInt)
       ).to.equal(false);
     });
 
@@ -89,14 +88,14 @@ describe('typeComparators', () => {
     it('non-null is subtype of nullable', () => {
       const schema = testSchema({ field: { type: GraphQLString } });
       expect(
-        isTypeSubTypeOf(schema, new GraphQLNonNull(GraphQLInt), GraphQLInt)
+        isTypeSubTypeOf(schema, GraphQLInt.wrapNonNull(), GraphQLInt)
       ).to.equal(true);
     });
 
     it('nullable is not subtype of non-null', () => {
       const schema = testSchema({ field: { type: GraphQLString } });
       expect(
-        isTypeSubTypeOf(schema, GraphQLInt, new GraphQLNonNull(GraphQLInt))
+        isTypeSubTypeOf(schema, GraphQLInt, GraphQLInt.wrapNonNull())
       ).to.equal(false);
     });
 

--- a/src/utilities/__tests__/valueFromAST-test.js
+++ b/src/utilities/__tests__/valueFromAST-test.js
@@ -16,7 +16,6 @@ import {
   GraphQLString,
   GraphQLBoolean,
   GraphQLID,
-  GraphQLNonNull,
 } from '../../type';
 import { parseValue } from '../../language';
 
@@ -83,15 +82,15 @@ describe('valueFromAST', () => {
   });
 
   // Boolean!
-  const nonNullBool = new GraphQLNonNull(GraphQLBoolean);
+  const nonNullBool = GraphQLBoolean.wrapNonNull();
   // [Boolean]
   const listOfBool = GraphQLBoolean.wrapList();
   // [Boolean!]
   const listOfNonNullBool = nonNullBool.wrapList();
   // [Boolean]!
-  const nonNullListOfBool = new GraphQLNonNull(listOfBool);
+  const nonNullListOfBool = listOfBool.wrapNonNull();
   // [Boolean!]!
-  const nonNullListOfNonNullBool = new GraphQLNonNull(listOfNonNullBool);
+  const nonNullListOfNonNullBool = listOfNonNullBool.wrapNonNull();
 
   it('coerces to null unless non-null', () => {
     testCase(GraphQLBoolean, 'null', null);

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -99,7 +99,7 @@ function buildWrappedType(
   if (inputTypeNode.kind === Kind.NON_NULL_TYPE) {
     const wrappedType = buildWrappedType(innerType, inputTypeNode.type);
     invariant(!(wrappedType instanceof GraphQLNonNull), 'No nesting nonnull.');
-    return new GraphQLNonNull(wrappedType);
+    return wrappedType.wrapNonNull();
   }
   return innerType;
 }

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -132,7 +132,7 @@ export function buildClientSchema(
         !(nullableType instanceof GraphQLNonNull),
         'No nesting nonnull.'
       );
-      return new GraphQLNonNull(nullableType);
+      return nullableType.wrapNonNull();
     }
     return getNamedType(typeRef.name);
   }

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -590,7 +590,7 @@ export function extendSchema(
     if (typeNode.kind === Kind.NON_NULL_TYPE) {
       const nullableType = buildInputFieldType(typeNode.type);
       invariant(!(nullableType instanceof GraphQLNonNull), 'Must be nullable');
-      return new GraphQLNonNull(nullableType);
+      return nullableType.wrapNonNull();
     }
     return getInputTypeFromAST(typeNode);
   }
@@ -602,7 +602,7 @@ export function extendSchema(
     if (typeNode.kind === Kind.NON_NULL_TYPE) {
       const nullableType = buildOutputFieldType(typeNode.type);
       invariant(!(nullableType instanceof GraphQLNonNull), 'Must be nullable');
-      return new GraphQLNonNull(nullableType);
+      return nullableType.wrapNonNull();
     }
     return getOutputTypeFromAST(typeNode);
   }

--- a/src/utilities/typeFromAST.js
+++ b/src/utilities/typeFromAST.js
@@ -49,7 +49,7 @@ function typeFromASTImpl(schema, typeNode) {
   }
   if (typeNode.kind === Kind.NON_NULL_TYPE) {
     innerType = typeFromAST(schema, typeNode.type);
-    return innerType && new GraphQLNonNull(innerType);
+    return innerType && innerType.wrapNonNull();
   }
   invariant(typeNode.kind === Kind.NAMED_TYPE, 'Must be a named type.');
   return schema.getType(typeNode.name.value);

--- a/src/validation/__tests__/OverlappingFieldsCanBeMerged-test.js
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMerged-test.js
@@ -21,7 +21,6 @@ import {
   GraphQLSchema,
   GraphQLObjectType,
   GraphQLInterfaceType,
-  GraphQLNonNull,
   GraphQLInt,
   GraphQLString,
   GraphQLID,
@@ -507,7 +506,7 @@ describe('Validate: Overlapping fields can be merged', () => {
       name: 'NonNullStringBox1',
       resolveType: () => StringBox,
       fields: {
-        scalar: { type: new GraphQLNonNull(GraphQLString) }
+        scalar: { type: GraphQLString.wrapNonNull() }
       }
     });
 
@@ -515,7 +514,7 @@ describe('Validate: Overlapping fields can be merged', () => {
       name: 'NonNullStringBox1Impl',
       interfaces: [ SomeBox, NonNullStringBox1 ],
       fields: {
-        scalar: { type: new GraphQLNonNull(GraphQLString) },
+        scalar: { type: GraphQLString.wrapNonNull() },
         unrelatedField: { type: GraphQLString },
         deepBox: { type: SomeBox },
       }
@@ -525,7 +524,7 @@ describe('Validate: Overlapping fields can be merged', () => {
       name: 'NonNullStringBox2',
       resolveType: () => StringBox,
       fields: {
-        scalar: { type: new GraphQLNonNull(GraphQLString) }
+        scalar: { type: GraphQLString.wrapNonNull() }
       }
     });
 
@@ -533,7 +532,7 @@ describe('Validate: Overlapping fields can be merged', () => {
       name: 'NonNullStringBox2Impl',
       interfaces: [ SomeBox, NonNullStringBox2 ],
       fields: {
-        scalar: { type: new GraphQLNonNull(GraphQLString) },
+        scalar: { type: GraphQLString.wrapNonNull() },
         unrelatedField: { type: GraphQLString },
         deepBox: { type: SomeBox },
       }

--- a/src/validation/__tests__/harness.js
+++ b/src/validation/__tests__/harness.js
@@ -16,7 +16,6 @@ import {
   GraphQLUnionType,
   GraphQLEnumType,
   GraphQLInputObjectType,
-  GraphQLNonNull,
   GraphQLInt,
   GraphQLFloat,
   GraphQLString,
@@ -194,7 +193,7 @@ const FurColor = new GraphQLEnumType({
 const ComplexInput = new GraphQLInputObjectType({
   name: 'ComplexInput',
   fields: {
-    requiredField: { type: new GraphQLNonNull(GraphQLBoolean) },
+    requiredField: { type: GraphQLBoolean.wrapNonNull() },
     intField: { type: GraphQLInt },
     stringField: { type: GraphQLString },
     booleanField: { type: GraphQLBoolean },
@@ -214,7 +213,7 @@ const ComplicatedArgs = new GraphQLObjectType({
     },
     nonNullIntArgField: {
       type: GraphQLString,
-      args: { nonNullIntArg: { type: new GraphQLNonNull(GraphQLInt) } },
+      args: { nonNullIntArg: { type: GraphQLInt.wrapNonNull() } },
     },
     stringArgField: {
       type: GraphQLString,
@@ -247,8 +246,8 @@ const ComplicatedArgs = new GraphQLObjectType({
     multipleReqs: {
       type: GraphQLString,
       args: {
-        req1: { type: new GraphQLNonNull(GraphQLInt) },
-        req2: { type: new GraphQLNonNull(GraphQLInt) },
+        req1: { type: GraphQLInt.wrapNonNull() },
+        req2: { type: GraphQLInt.wrapNonNull() },
       },
     },
     multipleOpts: {
@@ -267,8 +266,8 @@ const ComplicatedArgs = new GraphQLObjectType({
     multipleOptAndReq: {
       type: GraphQLString,
       args: {
-        req1: { type: new GraphQLNonNull(GraphQLInt) },
-        req2: { type: new GraphQLNonNull(GraphQLInt) },
+        req1: { type: GraphQLInt.wrapNonNull() },
+        req2: { type: GraphQLInt.wrapNonNull() },
         opt1: {
           type: GraphQLInt,
           defaultValue: 0,

--- a/src/validation/rules/VariablesInAllowedPosition.js
+++ b/src/validation/rules/VariablesInAllowedPosition.js
@@ -72,5 +72,5 @@ export function VariablesInAllowedPosition(context: ValidationContext): any {
 function effectiveType(varType, varDef) {
   return !varDef.defaultValue || varType instanceof GraphQLNonNull ?
     varType :
-    new GraphQLNonNull(varType);
+    varType.wrapNonNull();
 }


### PR DESCRIPTION
@kadikraman As discussed, here are the changes that are additional to the ones in graphql/graphql-js#1054 - that PR also has the error messages, repro-ed here:

The declaration of the `wrapNonNull` method:

```
wrapNonNull(): GraphQLNonNull<*> { ... }
```

The strange type failure. It is particularly strange to me because the same syntax and type declarations work fine on the `wrapList` method. This is an excerpt of the error:

```
       Property `type` is incompatible:
        111:       type: GraphQLString.wrapNonNull(),
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ GraphQLNonNull. This type is incompatible with
        673:   type: GraphQLOutputType;
                     ^^^^^^^^^^^^^^^^^ union: GraphQLScalarType | GraphQLObjectType | GraphQLInterfaceType | GraphQLUnionType | GraphQLEnumType | type application of class `GraphQLList` | type application of class `GraphQLNonNull`. See: src/type/definition.js:673
```

It seems to be losing the "type application" on `GraphQLNonNull`. It did this even when I adjusted the return type of `wrapNonNull` from `GraphQLNonNull<*>` to `GraphQLNonNull<GraphQLScalarType>`. Any insight into why would be greatly appreciated!